### PR TITLE
use serial in tables instead of int for ids

### DIFF
--- a/src/database/databaseSchema.sql
+++ b/src/database/databaseSchema.sql
@@ -1,6 +1,6 @@
 /* 1. Users + login credentials */
 CREATE TABLE Users (
-    uid           INT PRIMARY KEY,
+    uid           SERIAL PRIMARY KEY,
     email         VARCHAR(255)  NOT NULL UNIQUE,
     password_hash CHAR(60)      NOT NULL,
     display_name  VARCHAR(50)
@@ -8,7 +8,7 @@ CREATE TABLE Users (
 
 /* 2. One journal entry per user per day */
 CREATE TABLE JournalEntries (
-    entry_id    INT PRIMARY KEY,
+    entry_id    SERIAL PRIMARY KEY,
     uid         INT NOT NULL,
     entry_date  DATE NOT NULL,
     content     TEXT,
@@ -19,7 +19,7 @@ CREATE TABLE JournalEntries (
 
 /* 3. Per-entry tags */
 CREATE TABLE EntryTags (
-    tag_id   INT PRIMARY KEY,
+    tag_id   SERIAL PRIMARY KEY,
     entry_id INT NOT NULL,
     name     VARCHAR(30) NOT NULL,
     UNIQUE (entry_id, name),                         -- no dup tags in one entry
@@ -28,7 +28,7 @@ CREATE TABLE EntryTags (
 
 /* 4. Images attached to a journal entry (new) */
 CREATE TABLE Images (
-    image_id  INT PRIMARY KEY,
+    image_id  SERIAL PRIMARY KEY,
     entry_id  INT NOT NULL,
     file_path VARCHAR(255) NOT NULL,                 -- e.g. 'user1/2025-06-18/pic.jpg'
     caption   VARCHAR(100),


### PR DESCRIPTION
- Serial (in PostgreSQL) allows us to auto-increment our IDs instead of needing to pass in a specific int value