### PR TITLE
Add monthly recap page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ npm run dev
   - To be implemented: tags and images (in Milestone 2)
 - **Modern UI:**
   - Responsive, glassmorphic design with Tailwind and shadcn/ui components.
+- **Mood Analytics:**
+  - Monthly mood summaries are computed in a materialized view for fast charts.
+  - A dedicated Monthly Recap page lets you select any month and view the mood breakdown.
 
 ---
 
@@ -84,3 +87,6 @@ npm run dev
 - `src/database/populateUsers.sql` — Sample users
 - `src/database/populateDatabase.sql` — Sample journal entries, tags, images
 - `src/scripts/generateHash.js` — Script to generate password hashes for users
+- `src/database/queries/mv_monthly_mood.sql` — Materialized view for monthly mood counts
+- `src/database/queries/get_monthly_mood_summary.sql` — Helper function to query the view
+- `src/database/queries/refresh_mv_monthly_mood.sql` — Refresh utility for the view

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Login from "./pages/Login";
 import SignUp from "./pages/SignUp";
+import MonthlyRecap from "./pages/MonthlyRecap";
 
 const queryClient = new QueryClient();
 
@@ -20,6 +21,7 @@ const App = () => (
           <Route path="/" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />
           <Route path="/calendar" element={<Index />} />
+          <Route path="/recap" element={<MonthlyRecap />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/database/queries/get_monthly_mood_summary.sql
+++ b/src/database/queries/get_monthly_mood_summary.sql
@@ -1,0 +1,19 @@
+-- Function to read from the monthly mood materialized view
+create or replace function get_monthly_mood_summary(
+  user_id int,
+  start_date date,
+  end_date date
+)
+returns table (
+  month date,
+  mood text,
+  mood_count int
+)
+language sql
+as $$
+  select month, mood, mood_count
+  from mv_monthly_mood
+  where uid = user_id
+    and month between date_trunc('month', start_date) and date_trunc('month', end_date)
+  order by month, mood;
+$$;

--- a/src/database/queries/mv_monthly_mood.sql
+++ b/src/database/queries/mv_monthly_mood.sql
@@ -1,0 +1,12 @@
+-- Materialized view summarizing mood counts per user per month
+create materialized view mv_monthly_mood as
+select
+  uid,
+  date_trunc('month', entry_date) as month,
+  mood,
+  count(*) as mood_count
+from journalentries
+group by uid, month, mood;
+
+create index idx_mv_monthly_mood_uid_month
+  on mv_monthly_mood (uid, month);

--- a/src/database/queries/refresh_mv_monthly_mood.sql
+++ b/src/database/queries/refresh_mv_monthly_mood.sql
@@ -1,0 +1,7 @@
+-- Utility function to refresh the monthly mood materialized view
+create or replace function refresh_mv_monthly_mood()
+returns void language plpgsql as $$
+begin
+  refresh materialized view mv_monthly_mood;
+end;
+$$;

--- a/src/lib/journalService.ts
+++ b/src/lib/journalService.ts
@@ -126,3 +126,29 @@ export const loadJournalEntry = async (
 };
 
 
+
+export const getMonthlyMoodSummary = async (
+  start: Date,
+  end: Date
+): Promise<{ data?: { month: string; mood: string; mood_count: number }[]; error?: string }> => {
+  try {
+    const user = getCurrentUser();
+    if (!user || !user.uid) {
+      return { error: 'User not authenticated. Please log in.' };
+    }
+    const startDate = format(start, 'yyyy-MM-dd');
+    const endDate = format(end, 'yyyy-MM-dd');
+    const { data, error } = await supabase.rpc('get_monthly_mood_summary', {
+      user_id: user.uid,
+      start_date: startDate,
+      end_date: endDate
+    });
+    if (error) {
+      return { error: error.message };
+    }
+    return { data };
+  } catch (error) {
+    return { error: 'Failed to fetch mood summary' };
+  }
+};
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Calendar from '@/components/Calendar';
 import JournalEntry from '@/components/JournalEntry';
 import { format } from 'date-fns';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import icon from '@/lib/images/icon.png';
 
 const Index = () => {
@@ -49,6 +49,7 @@ const Index = () => {
               <div className="text-slate-600 font-medium">
                 {format(new Date(), 'EEEE, MMMM d, yyyy')}
               </div>
+              <Link to="/recap" className="text-blue-600 hover:underline">Monthly Recap</Link>
             </div>
             <button
                 onClick={handleLogout}

--- a/src/pages/MonthlyRecap.tsx
+++ b/src/pages/MonthlyRecap.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import { format, startOfMonth, endOfMonth } from 'date-fns';
+import { useNavigate, Link } from 'react-router-dom';
+import { getMonthlyMoodSummary } from '@/lib/journalService';
+import { Button } from '@/components/ui/button';
+
+interface MoodSummaryRow {
+  month: string;
+  mood: string;
+  mood_count: number;
+}
+
+const MonthlyRecap = () => {
+  const navigate = useNavigate();
+  const [month, setMonth] = useState<string>(format(new Date(), 'yyyy-MM'));
+  const [summary, setSummary] = useState<MoodSummaryRow[]>([]);
+
+  useEffect(() => {
+    const user = sessionStorage.getItem('user');
+    if (!user) {
+      navigate('/');
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    async function load() {
+      const baseDate = new Date(month + '-01');
+      const start = startOfMonth(baseDate);
+      const end = endOfMonth(baseDate);
+      const { data } = await getMonthlyMoodSummary(start, end);
+      if (data) {
+        setSummary(data);
+      } else {
+        setSummary([]);
+      }
+    }
+    load();
+  }, [month]);
+
+  const handleLogout = () => {
+    sessionStorage.clear();
+    navigate('/');
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
+      <header className="bg-white/80 backdrop-blur-xl border-b border-slate-200/50 sticky top-0 z-50">
+        <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <h1 className="text-2xl font-semibold text-slate-800">Monthly Recap</h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Link to="/calendar" className="text-blue-600 hover:underline">Calendar</Link>
+            </div>
+            <Button onClick={handleLogout} className="ml-4">Log out</Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-8 space-y-8">
+        <div className="flex justify-center">
+          <input
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="border p-2 rounded-md"
+          />
+        </div>
+        <div className="bg-white rounded-xl shadow p-6">
+          <h2 className="text-lg font-semibold mb-4">
+            Mood Summary for {format(new Date(month + '-01'), 'MMMM yyyy')}
+          </h2>
+          {summary.length === 0 ? (
+            <p className="text-slate-500">No data for this month.</p>
+          ) : (
+            <ul className="space-y-2">
+              {summary.map((row) => (
+                <li key={row.mood} className="flex justify-between">
+                  <span>{row.mood}</span>
+                  <span>{row.mood_count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default MonthlyRecap;


### PR DESCRIPTION
## Summary
- implement MonthlyRecap page that queries `getMonthlyMoodSummary`
- link the new page from the calendar header
- register /recap route
- document the new recap page in README