### PR TITLE
retitle button to Back

### DIFF
--- a/src/components/JournalEntry.tsx
+++ b/src/components/JournalEntry.tsx
@@ -165,7 +165,6 @@ const JournalEntry: React.FC<JournalEntryProps> = ({ date, entryId, onClose, onB
 
   return (
     <div className="max-w-4xl mx-auto">
-      {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center space-x-4">
           <Button
@@ -175,7 +174,7 @@ const JournalEntry: React.FC<JournalEntryProps> = ({ date, entryId, onClose, onB
             className="hover:bg-slate-100 rounded-xl"
           >
             <ArrowLeft className="h-4 w-4 mr-2" />
-            {onBackToFiltered ? 'Back to Filtered Results' : 'Back to Calendar'}
+            Back
           </Button>
         </div>
         <Button


### PR DESCRIPTION
back button had issue after filtering+updating where on regular calendar, it would say go back to filtered results. fixed to just always say "Back"